### PR TITLE
IDE compability (autogenerated qt files)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 # Visual Studio
 */.vs/*
 
+# Visual Studio Code / VS Codium
+*/.vscode/*
+
 # Cmake
 */CmakeLists.txt.user
 */cmake-build-debug/*

--- a/cuteInjector/CMakeLists.txt
+++ b/cuteInjector/CMakeLists.txt
@@ -54,6 +54,12 @@ qt_add_executable(cuteInjector
     ${RC_FILE}
 )
 
+# Autogen files in visual studio
+target_include_directories(cuteInjector
+    PUBLIC
+    ${CMAKE_CURRENT_BINARY_DIR}/cuteInjector_autogen/include
+)
+
 target_link_libraries(cuteInjector PRIVATE Qt${QT_VERSION_MAJOR}::Widgets)
 
 set_target_properties(cuteInjector PROPERTIES

--- a/cuteInjector/src/ui/mainWindow.cpp
+++ b/cuteInjector/src/ui/mainWindow.cpp
@@ -1,5 +1,5 @@
 #include "mainWindow.h"
-#include "./ui_mainWindow.h"
+#include "ui_mainWindow.h"
 #include "textInfoWindow.h"
 #include "../helpers/jsonSerializer.h"
 


### PR DESCRIPTION
Autogenerated files like the .ui files of qt should now be auto included in Visual Studio and CMake.